### PR TITLE
feat: attendee table added in health camp 

### DIFF
--- a/changemakers/api/__init__.py
+++ b/changemakers/api/__init__.py
@@ -15,6 +15,8 @@ MOBILE_SUPPORTED_FIELD_TYPES = [
 	"Check",
 	"Geolocation",
 	"Attach",
+	"Small Text",
+	"Section Break",
 ]
 
 

--- a/changemakers/frappe_changemakers/doctype/health_camp_attendee/health_camp_attendee.json
+++ b/changemakers/frappe_changemakers/doctype/health_camp_attendee/health_camp_attendee.json
@@ -1,0 +1,50 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:beneficiary",
+ "creation": "2023-06-18 17:59:40.404909",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "beneficiary",
+  "age",
+  "gender"
+ ],
+ "fields": [
+  {
+   "fieldname": "beneficiary",
+   "fieldtype": "Link",
+   "label": "Beneficiary",
+   "options": "Beneficiary",
+   "unique": 1
+  },
+  {
+   "fetch_from": "beneficiary.age",
+   "fieldname": "age",
+   "fieldtype": "Data",
+   "label": "Age",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "beneficiary.gender",
+   "fieldname": "gender",
+   "fieldtype": "Data",
+   "label": "Gender",
+   "read_only": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2023-06-19 01:48:37.674384",
+ "modified_by": "Administrator",
+ "module": "Frappe Changemakers",
+ "name": "Health Camp Attendee",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/changemakers/frappe_changemakers/doctype/health_camp_attendee/health_camp_attendee.py
+++ b/changemakers/frappe_changemakers/doctype/health_camp_attendee/health_camp_attendee.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, hussain@frappe.io and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class HealthCampAttendee(Document):
+	pass

--- a/changemakers/frappe_changemakers/doctype/health_camp_record/health_camp_record.json
+++ b/changemakers/frappe_changemakers/doctype/health_camp_record/health_camp_record.json
@@ -17,6 +17,7 @@
   "number_of_males",
   "number_of_children",
   "total_patients_screened",
+  "healthcamp_attendees",
   "column_break_rsms",
   "number_of_females",
   "number_of_others",
@@ -204,11 +205,17 @@
   {
    "fieldname": "column_break_aqvh",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "healthcamp_attendees",
+   "fieldtype": "Table",
+   "label": "Healthcamp Attendees",
+   "options": "Health Camp Attendee"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-03-05 11:37:59.037699",
+ "modified": "2023-06-18 18:03:05.637821",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Health Camp Record",

--- a/changemakers/frappe_changemakers/doctype/health_camp_record/health_camp_record.py
+++ b/changemakers/frappe_changemakers/doctype/health_camp_record/health_camp_record.py
@@ -1,12 +1,13 @@
 # Copyright (c) 2022, hussain@frappe.io and contributors
 # For license information, please see license.txt
 
-# import frappe
+import frappe
 from frappe.model.document import Document
 
 
 class HealthCampRecord(Document):
 	def validate(self):
+		self.update_patient_count()
 		self.set_total_patients_screened()
 
 	def set_total_patients_screened(self):
@@ -16,3 +17,28 @@ class HealthCampRecord(Document):
 			+ (self.number_of_children or 0)
 			+ (self.number_of_others or 0)
 		)
+
+	def update_patient_count(self):
+		self.number_of_males = 0
+		self.number_of_females = 0
+		self.number_of_children = 0
+		self.number_of_others = 0
+
+		for patient in self.healthcamp_attendees:
+			beneficiary_name = get_beneficiary_name(str(patient))
+			beneficiary = frappe.get_doc("Beneficiary", beneficiary_name)
+			if beneficiary.age > 13:
+				if beneficiary.gender == "Male":
+					self.number_of_males += 1
+				elif beneficiary.gender == "Female":
+					self.number_of_females += 1
+				else:
+					self.number_of_others += 1
+			else:
+				self.number_of_children += 1
+
+
+def get_beneficiary_name(patient):
+	start_index = patient.find("(") + 1
+	end_index = patient.find(")")
+	return patient[start_index:end_index]

--- a/frontend/src/components/FormView.vue
+++ b/frontend/src/components/FormView.vue
@@ -141,6 +141,8 @@ const formFields = createResource({
 			Datetime: "datetime",
 			Geolocation: "geolocation",
 			Attach: "attach",
+			"Small Text": "textarea",
+			"Section Break": "section-break",
 		}
 
 		return fields.map((field) => ({

--- a/frontend/src/components/core/FormField.vue
+++ b/frontend/src/components/core/FormField.vue
@@ -83,10 +83,24 @@
 			@change="handleFileSelect"
 		/>
 	</div>
-
+	<div v-else-if="props.type === 'section-break'">
+		<h2 class="pt-2 text-lg font-semibold">{{ props.label }}</h2>
+	</div>
+	<div v-else-if="props.type === 'textarea'">
+		<span class="mb-2 block text-left text-sm leading-4 text-gray-700">
+			{{ props.label }}
+		</span>
+		<textarea
+			:value="modelValue"
+			class="form-textarea block h-20 w-full"
+			v-bind="$attrs"
+			@input="(v) => emit('update:modelValue', v.target.value)"
+			@change="(v) => emit('change', v.target.value)"
+			@blur="onBlur"
+		></textarea>
+	</div>
 	<Input
 		v-else
-		:readonly="props.readOnly"
 		:type="props.type"
 		:value="modelValue"
 		:label="props.label"
@@ -96,6 +110,10 @@
 		@blur="onBlur"
 		v-bind="$attrs"
 	/>
+	<!-- <div>
+		{{ props }}
+	</div> -->
+
 	<ErrorMessage
 		v-if="validation?.meta?.touched"
 		:message="validation?.errorMessage"


### PR DESCRIPTION
Now you can add beneficiaries in the table given in the health camp directly. The number of attendees will be handled automatically according to the beneficiaries attending the health camp.

closes #91 

![Screen Recording - June 19, 2023](https://github.com/frappe/changemakers/assets/73123690/0b70921b-5efb-45ab-a68c-e52e8990f9a4)

