### PR TITLE
feat: tickets hiding & case type fixture

### DIFF
--- a/changemakers/fixtures/case_type.json
+++ b/changemakers/fixtures/case_type.json
@@ -1,0 +1,42 @@
+[
+ {
+  "docstatus": 0,
+  "doctype": "Case Type",
+  "is_enabled": 1,
+  "modified": "2023-06-18 01:22:55.445919",
+  "name": "Shelter",
+  "type": "Shelter"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Case Type",
+  "is_enabled": 1,
+  "modified": "2023-06-18 01:23:01.138360",
+  "name": "Medical",
+  "type": "Medical"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Case Type",
+  "is_enabled": 1,
+  "modified": "2023-06-18 01:23:05.368430",
+  "name": "Food",
+  "type": "Food"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Case Type",
+  "is_enabled": 1,
+  "modified": "2023-06-18 01:23:46.368805",
+  "name": "Other",
+  "type": "Other"
+ },
+ {
+  "docstatus": 0,
+  "doctype": "Case Type",
+  "is_enabled": 1,
+  "modified": "2023-06-18 01:26:14.586694",
+  "name": "Hygiene",
+  "type": "Hygiene"
+ }
+]

--- a/changemakers/frappe_changemakers/doctype/case/case.js
+++ b/changemakers/frappe_changemakers/doctype/case/case.js
@@ -6,6 +6,13 @@ frappe.ui.form.on("Case", {
 		changemakers.utils.set_query_for_district(frm);
 		changemakers.utils.set_query_for_zone(frm);
 		changemakers.utils.set_query_for_ward(frm);
+		frm.set_query("type", () => {
+			return {
+				filters: {
+					is_enabled: 1,
+				},
+			};
+		});
 	},
 	state: changemakers.utils.handle_state_field,
 	district: changemakers.utils.handle_district_field,

--- a/changemakers/frappe_changemakers/doctype/case_type/case_type.json
+++ b/changemakers/frappe_changemakers/doctype/case_type/case_type.json
@@ -7,7 +7,8 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "type"
+  "type",
+  "is_enabled"
  ],
  "fields": [
   {
@@ -15,10 +16,16 @@
    "fieldtype": "Data",
    "label": "Type",
    "unique": 1
+  },
+  {
+   "default": "1",
+   "fieldname": "is_enabled",
+   "fieldtype": "Check",
+   "label": "Is Enabled?"
   }
  ],
  "links": [],
- "modified": "2023-06-18 01:15:00.132154",
+ "modified": "2023-06-20 14:21:32.583819",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Case Type",

--- a/changemakers/hooks.py
+++ b/changemakers/hooks.py
@@ -10,6 +10,7 @@ app_license = "AGPL"
 
 fixtures = [
 	"Custom HTML Block",
+	"Case Type",
 	"State",
 	{"dt": "Client Script", "filters": {"name": "Action: Create User Profile"}},
 	{


### PR DESCRIPTION
You can create new case types as doctype
![image](https://github.com/frappe/changemakers/assets/73123690/95cf7b3b-09fa-40c3-9ea6-2ae516bbd426)


You can hide tickets by disabling 'Is Enabled' in the Case Type Doctype.
![image](https://github.com/frappe/changemakers/assets/73123690/c474e935-9909-4c96-a4af-5a3e029f84b4)

fixes #90 #92 