### PR TITLE
feat: created by field in doctypes for export (#113)

### DIFF
--- a/changemakers/frappe_changemakers/doctype/beneficiary/beneficiary.json
+++ b/changemakers/frappe_changemakers/doctype/beneficiary/beneficiary.json
@@ -59,6 +59,8 @@
   "column_break_40",
   "employment_type",
   "other_employment_type",
+  "section_break_vzck",
+  "created_by",
   "section_break_uwdz",
   "bottom_save_button"
  ],
@@ -86,6 +88,7 @@
    "fieldtype": "Link",
    "in_standard_filter": 1,
    "label": "Ward/GP",
+   "length": 600,
    "options": "Ward"
   },
   {
@@ -361,6 +364,16 @@
    "fieldtype": "Table MultiSelect",
    "label": "Languages Known",
    "options": "Language Multiselect"
+  },
+  {
+   "fieldname": "section_break_vzck",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "created_by",
+   "fieldtype": "Data",
+   "label": "Created By",
+   "read_only": 1
   }
  ],
  "image_field": "image",
@@ -387,7 +400,7 @@
    "link_fieldname": "beneficiary"
   }
  ],
- "modified": "2023-08-22 10:28:30.184399",
+ "modified": "2023-09-05 17:03:01.300560",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Beneficiary",

--- a/changemakers/frappe_changemakers/doctype/beneficiary/beneficiary.py
+++ b/changemakers/frappe_changemakers/doctype/beneficiary/beneficiary.py
@@ -11,6 +11,7 @@ class Beneficiary(Document):
 	def validate(self):
 		self.validate_age()
 		self.validate_phone_number_fields()
+		self.set_created_by()
 
 	def validate_age(self):
 		if not (self.age < 120):
@@ -24,3 +25,7 @@ class Beneficiary(Document):
 
 		if self.phone_number and not is_valid_indian_phone_number(self.phone_number):
 			frappe.throw(f"Value of {frappe.bold('Phone')} is not a valid Indian Phone number")
+
+	def set_created_by(self):
+		if not self.created_by:
+			self.created_by = self.owner

--- a/changemakers/frappe_changemakers/doctype/beneficiary/beneficiary.py
+++ b/changemakers/frappe_changemakers/doctype/beneficiary/beneficiary.py
@@ -8,10 +8,12 @@ from changemakers.utils.data import is_valid_indian_phone_number
 
 
 class Beneficiary(Document):
+	def before_save(self):
+		self.set_created_by()
+
 	def validate(self):
 		self.validate_age()
 		self.validate_phone_number_fields()
-		self.set_created_by()
 
 	def validate_age(self):
 		if not (self.age < 120):

--- a/changemakers/frappe_changemakers/doctype/case/case.json
+++ b/changemakers/frappe_changemakers/doctype/case/case.json
@@ -46,6 +46,9 @@
   "follow_up_details_section",
   "family_meeting_outcome",
   "followups",
+  "data_cjaa",
+  "section_break_seoz",
+  "created_by",
   "section_break_yuho",
   "bottom_save_button",
   "column_break_qfjk"
@@ -310,11 +313,25 @@
   {
    "fieldname": "section_break_ajqf",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "data_cjaa",
+   "fieldtype": "Data"
+  },
+  {
+   "fieldname": "section_break_seoz",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "created_by",
+   "fieldtype": "Data",
+   "label": "Created By",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-07-08 01:09:06.876317",
+ "modified": "2023-09-05 17:04:47.689828",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Case",

--- a/changemakers/frappe_changemakers/doctype/case/case.py
+++ b/changemakers/frappe_changemakers/doctype/case/case.py
@@ -6,4 +6,9 @@ from frappe.model.document import Document
 
 
 class Case(Document):
-	pass
+	def before_save(self):
+		self.set_created_by()
+
+	def set_created_by(self):
+		if not self.created_by:
+			self.created_by = self.owner

--- a/changemakers/frappe_changemakers/doctype/daily_visit_update/daily_visit_update.json
+++ b/changemakers/frappe_changemakers/doctype/daily_visit_update/daily_visit_update.json
@@ -10,7 +10,9 @@
  "field_order": [
   "beneficiary",
   "date",
-  "daily_update"
+  "daily_update",
+  "section_break_naow",
+  "created_by"
  ],
  "fields": [
   {
@@ -36,11 +38,21 @@
    "fieldtype": "Text",
    "in_list_view": 1,
    "label": "Daily Update"
+  },
+  {
+   "fieldname": "section_break_naow",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "created_by",
+   "fieldtype": "Data",
+   "label": "Created by",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-07-16 16:25:54.521737",
+ "modified": "2023-09-05 17:11:41.703890",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Daily Visit Update",

--- a/changemakers/frappe_changemakers/doctype/daily_visit_update/daily_visit_update.py
+++ b/changemakers/frappe_changemakers/doctype/daily_visit_update/daily_visit_update.py
@@ -9,3 +9,10 @@ class DailyVisitUpdate(Document):
 	def before_naming(self):
 		if not self.date:
 			self.date = today()
+
+	def before_save(self):
+		self.set_created_by()
+
+	def set_created_by(self):
+		if not self.created_by:
+			self.created_by = self.owner

--- a/changemakers/frappe_changemakers/doctype/rescue/rescue.json
+++ b/changemakers/frappe_changemakers/doctype/rescue/rescue.json
@@ -43,6 +43,8 @@
   "police_memo",
   "section_break_zcfc",
   "other_remarks",
+  "section_break_ubix",
+  "created_by",
   "section_break_vjqi",
   "bottom_save_button",
   "amended_from",
@@ -273,12 +275,22 @@
    "fieldname": "bottom_save_button",
    "fieldtype": "Button",
    "label": "Save"
+  },
+  {
+   "fieldname": "section_break_ubix",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "created_by",
+   "fieldtype": "Data",
+   "label": "Created by",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-03-05 11:31:01.409990",
+ "modified": "2023-09-05 17:08:57.368937",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Rescue",

--- a/changemakers/frappe_changemakers/doctype/rescue/rescue.py
+++ b/changemakers/frappe_changemakers/doctype/rescue/rescue.py
@@ -12,6 +12,13 @@ class Rescue(Document):
 		self.validate_remarks_length()
 		self.set_location_coordinates()
 
+	def before_save(self):
+		self.set_created_by()
+
+	def set_created_by(self):
+		if not self.created_by:
+			self.created_by = self.owner
+
 	def validate_remarks_length(self):
 		if self.other_remarks and len(self.other_remarks) > 300:
 			frappe.throw("Other remarks cannot be more than 300 characters long.")


### PR DESCRIPTION
`Created By` field introduced in the doctypes which now holds the `owner` value. The person who created the doctype will have their email be auto-populated in this field when the doctype is saved. This field is a `read-only` field.

Closes #113 