### PR TITLE
fix: location cascading in doctypes #118

### DIFF
--- a/changemakers/frappe_changemakers/doctype/beneficiary/beneficiary.json
+++ b/changemakers/frappe_changemakers/doctype/beneficiary/beneficiary.json
@@ -21,12 +21,10 @@
   "social_category",
   "location_section",
   "state",
-  "ward",
-  "column_break_8",
   "district",
-  "habitation",
-  "column_break_9",
   "zone",
+  "ward",
+  "habitation",
   "identity_section",
   "is_identity_proof_available",
   "column_break_17",
@@ -151,17 +149,9 @@
    "label": "Location"
   },
   {
-   "fieldname": "column_break_9",
-   "fieldtype": "Column Break"
-  },
-  {
    "fieldname": "health_section",
    "fieldtype": "Section Break",
    "label": "Health"
-  },
-  {
-   "fieldname": "column_break_8",
-   "fieldtype": "Column Break"
   },
   {
    "fieldname": "identity_section",
@@ -400,7 +390,7 @@
    "link_fieldname": "beneficiary"
   }
  ],
- "modified": "2023-09-05 17:03:01.300560",
+ "modified": "2023-09-06 19:31:11.618589",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Beneficiary",

--- a/changemakers/frappe_changemakers/doctype/case/case.json
+++ b/changemakers/frappe_changemakers/doctype/case/case.json
@@ -18,14 +18,12 @@
   "amended_from",
   "location_section",
   "is_beneficiary_in_shelter_home",
-  "section_break_ajqf",
+  "section_break_grcq",
   "state",
-  "ward",
-  "column_break_eyby",
   "district",
-  "habitation",
-  "column_break_ouiz",
   "zone",
+  "ward",
+  "habitation",
   "shelter_home",
   "beneficiary_details_section",
   "is_beneficiary_traced",
@@ -200,10 +198,6 @@
    "label": "Location"
   },
   {
-   "fieldname": "column_break_eyby",
-   "fieldtype": "Column Break"
-  },
-  {
    "fieldname": "section_break_zguo",
    "fieldtype": "Section Break",
    "label": "Case Details"
@@ -306,14 +300,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "column_break_ouiz",
-   "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "section_break_ajqf",
-   "fieldtype": "Section Break"
-  },
-  {
    "fieldname": "data_cjaa",
    "fieldtype": "Data"
   },
@@ -326,11 +312,15 @@
    "fieldtype": "Data",
    "label": "Created By",
    "read_only": 1
+  },
+  {
+   "fieldname": "section_break_grcq",
+   "fieldtype": "Section Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-09-06 00:58:01.453261",
+ "modified": "2023-09-06 14:05:10.045885",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Case",

--- a/changemakers/frappe_changemakers/doctype/health_camp_record/health_camp_record.json
+++ b/changemakers/frappe_changemakers/doctype/health_camp_record/health_camp_record.json
@@ -28,11 +28,10 @@
   "specified_camp_location",
   "section_break_xgxk",
   "state",
-  "zone",
-  "habitation",
-  "column_break_oahi",
   "district",
+  "zone",
   "ward",
+  "habitation",
   "medical_details_section",
   "total_medicines_dispensed",
   "total_referrals_done",
@@ -40,7 +39,9 @@
   "total_diagnostics_done",
   "section_break_syqt",
   "bottom_save_button",
-  "column_break_aqvh"
+  "column_break_aqvh",
+  "section_break_7w59",
+  "mcrc_details"
  ],
  "fields": [
   {
@@ -136,10 +137,6 @@
    "reqd": 1
   },
   {
-   "fieldname": "column_break_oahi",
-   "fieldtype": "Column Break"
-  },
-  {
    "fieldname": "district",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -216,11 +213,21 @@
   {
    "fieldname": "section_break_aswu",
    "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "section_break_7w59",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "mcrc_details",
+   "fieldtype": "Table",
+   "label": "MCRC Details",
+   "options": "MCRC Daily Update"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-06-27 12:38:00.382742",
+ "modified": "2023-09-06 19:30:03.009355",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Health Camp Record",

--- a/changemakers/frappe_changemakers/doctype/rescue/rescue.json
+++ b/changemakers/frappe_changemakers/doctype/rescue/rescue.json
@@ -26,11 +26,10 @@
   "coordinates",
   "section_break_sslw",
   "state",
-  "zone",
-  "habitation",
-  "column_break_itmb",
   "district",
+  "zone",
   "ward",
+  "habitation",
   "post_rescue_details_section",
   "was_referred_to_hospital",
   "hospital",
@@ -250,10 +249,6 @@
    "options": "Habitation"
   },
   {
-   "fieldname": "column_break_itmb",
-   "fieldtype": "Column Break"
-  },
-  {
    "fieldname": "state",
    "fieldtype": "Link",
    "label": "State",
@@ -290,7 +285,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-09-05 17:08:57.368937",
+ "modified": "2023-09-06 19:28:44.208583",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Rescue",


### PR DESCRIPTION
#118 

The cascading is working fine, but the issue arises when a proper order is not followed while filling the fields. Hence, have decided to re-arrange the location detail fields in a simpler pattern.

Decided to change the arrangement in beneficiary too for the sake of uniformity.

![image](https://github.com/frappe/changemakers/assets/73123690/1dc896f1-ba1c-4f44-b9a7-1489c67c55c9)
