### PR TITLE
chore: beneficiary name in case export

### DIFF
--- a/changemakers/frappe_changemakers/doctype/beneficiary/beneficiary.json
+++ b/changemakers/frappe_changemakers/doctype/beneficiary/beneficiary.json
@@ -11,14 +11,15 @@
   "personal_information_section",
   "first_name",
   "last_name",
-  "phone_number",
+  "full_name",
   "column_break_3",
+  "phone_number",
   "gender",
   "age",
-  "languages_known",
   "column_break_4",
   "religion",
   "social_category",
+  "languages_known",
   "location_section",
   "state",
   "district",
@@ -364,6 +365,11 @@
    "fieldtype": "Data",
    "label": "Created By",
    "read_only": 1
+  },
+  {
+   "fieldname": "full_name",
+   "fieldtype": "Data",
+   "label": "Full Name"
   }
  ],
  "image_field": "image",
@@ -390,7 +396,7 @@
    "link_fieldname": "beneficiary"
   }
  ],
- "modified": "2023-09-06 19:31:11.618589",
+ "modified": "2023-09-06 21:25:52.624848",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Beneficiary",

--- a/changemakers/frappe_changemakers/doctype/beneficiary/beneficiary.py
+++ b/changemakers/frappe_changemakers/doctype/beneficiary/beneficiary.py
@@ -10,6 +10,7 @@ from changemakers.utils.data import is_valid_indian_phone_number
 class Beneficiary(Document):
 	def before_save(self):
 		self.set_created_by()
+		self.full_name = f"{self.first_name} {self.last_name or ''}"
 
 	def validate(self):
 		self.validate_age()

--- a/changemakers/frappe_changemakers/doctype/case/case.json
+++ b/changemakers/frappe_changemakers/doctype/case/case.json
@@ -28,8 +28,9 @@
   "beneficiary_details_section",
   "is_beneficiary_traced",
   "beneficiary",
-  "gender",
+  "full_name",
   "column_break_jywm",
+  "gender",
   "age",
   "contact_number",
   "updates_section",
@@ -44,7 +45,6 @@
   "follow_up_details_section",
   "family_meeting_outcome",
   "followups",
-  "data_cjaa",
   "section_break_seoz",
   "created_by",
   "section_break_yuho",
@@ -300,10 +300,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "data_cjaa",
-   "fieldtype": "Data"
-  },
-  {
    "fieldname": "section_break_seoz",
    "fieldtype": "Section Break"
   },
@@ -316,11 +312,17 @@
   {
    "fieldname": "section_break_grcq",
    "fieldtype": "Section Break"
+  },
+  {
+   "fetch_from": "beneficiary.full_name",
+   "fieldname": "full_name",
+   "fieldtype": "Data",
+   "label": "Name"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-09-06 14:05:10.045885",
+ "modified": "2023-09-06 21:55:35.529923",
  "modified_by": "Administrator",
  "module": "Frappe Changemakers",
  "name": "Case",


### PR DESCRIPTION
#120 

Introduced a Full name field in beneficiary, which will be auto-set using first name and last name. Fetched this field in case doctype via beneficiary link. Beneficiary name can be exported in cases now, 